### PR TITLE
fix: can not reload component without refresh page

### DIFF
--- a/packages/planet/src/component/planet-component-loader.ts
+++ b/packages/planet/src/component/planet-component-loader.ts
@@ -151,7 +151,7 @@ export class PlanetComponentLoader {
         const result = this.getPlantAppRef(app).pipe(
             delayWhen(appRef => {
                 if (appRef.getComponentFactory()) {
-                    return of();
+                    return of('');
                 } else {
                     // Because register use 'setTimeout',so timer 20
                     return timer(20);


### PR DESCRIPTION
https://github.com/ReactiveX/rxjs/blob/master/spec/operators/delayWhen-spec.ts#L301

Rxjs v7 这个单元测试如果改成
```
of(1)
      .pipe(delayWhen(() => of()))
      .subscribe({ next: () => (next = true), complete: () => (complete = true) });
```
就会失败，of() 不传参数不会触发流

_ps: Rxjs v6 好像没问题。如果其他人适用了 v7 版本的 rxjs 就会有问题了。planet 可以考虑升级一下 rxjs_