### PR TITLE
feat: add planetComponentOutlet and refactor attachComponent, remove wrapper element and cdk

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,7 @@
         "@angular-eslint/component-selector": [
           "error",
           {
-            "prefix": "lib",
+            "prefix": "planet",
             "style": "kebab-case",
             "type": "element"
           }
@@ -21,7 +21,7 @@
         "@angular-eslint/directive-selector": [
           "error",
           {
-            "prefix": "lib",
+            "prefix": "planet",
             "style": "camelCase",
             "type": "attribute"
           }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ yarn add @worktile/planet
 
 ## Dependencies
 
-- `@angular/cdk`, you should install `@angular/cdk`
+- `<= 14.0.0` you should install `@angular/cdk`
 
 ## Demo
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,7 +39,7 @@ $ yarn add @worktile/planet
 
 ## Dependencies
 
-- `@angular/cdk`, 确保安装了 Angular 官方的 CDK `npm i @angular/cdk --save` 或者 `yarn add @angular/cdk`
+- 在 `<= 14.0.0`，确保安装了 Angular 官方的 CDK `npm i @angular/cdk --save` 或者 `yarn add @angular/cdk`
 
 
 ## 示例

--- a/examples/app1/src/app/projects/projects.component.ts
+++ b/examples/app1/src/app/projects/projects.component.ts
@@ -1,33 +1,79 @@
-import { Observable } from 'rxjs';
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
-import { PlanetComponentLoader } from 'ngx-planet';
+import { Observable, Subject } from 'rxjs';
+import { Component, ElementRef, OnInit, ViewChild, OnDestroy } from '@angular/core';
+import { PlanetComponentLoader, PlanetComponentRef } from 'ngx-planet';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
     selector: 'app-projects',
     template: `
         <section-card class="mt-2" title="App2's projects component">
-            <thy-loading [thyDone]="loadingDone"></thy-loading>
-            <div #container></div>
+            <thy-tabs (thyActiveTabChange)="activeTabChange($event)">
+                <thy-tab id="planet-component-outlet" thyTitle="PlanetComponentOutlet">
+                    <ng-container
+                        *planetComponentOutlet="
+                            'project1';
+                            app: 'app2';
+                            initialState: { search: 'From PlanetComponentOutlet' }
+                        "
+                    ></ng-container>
+                    <!-- <ng-container
+                        planetComponentOutlet="project1"
+                        planetComponentOutletApp="app2"
+                        (planetComponentLoad)="planetComponentLoad()"
+                    ></ng-container> -->
+                </thy-tab>
+                <thy-tab id="planet-component-loader" thyTitle="PlanetComponentLoader">
+                    <div #container></div>
+                </thy-tab>
+            </thy-tabs>
+            <!-- <thy-loading [thyDone]="loadingDone"></thy-loading> -->
         </section-card>
     `
 })
-export class ProjectsComponent implements OnInit {
-    @ViewChild('container', { static: true }) elementRef: ElementRef<HTMLDivElement>;
+export class ProjectsComponent implements OnInit, OnDestroy {
+    @ViewChild('container', { static: true }) container: ElementRef<HTMLDivElement>;
 
     loadingDone = false;
 
+    destroyed$ = new Subject<void>();
+
+    componentRef: PlanetComponentRef;
+
     constructor(private planetComponentLoader: PlanetComponentLoader) {}
 
-    ngOnInit() {
+    ngOnInit() {}
+
+    activeTabChange(event: string) {
+        if (event === 'planet-component-loader') {
+            this.loadManual();
+        }
+    }
+
+    loadManual() {
+        this.componentRef?.dispose();
         this.planetComponentLoader
             .load<{ click: Observable<unknown> }>('app2', 'project1', {
-                container: this.elementRef
+                container: this.container,
+                initialState: {
+                    search: 'From PlanetComponentLoader'
+                },
+                wrapperClass: 'wrapper-class'
             })
+            .pipe(takeUntil(this.destroyed$))
             .subscribe(componentRef => {
                 this.loadingDone = true;
+                this.componentRef = componentRef;
                 componentRef.componentInstance.click.subscribe(() => {
                     console.log('project item clicked');
                 });
             });
+    }
+
+    planetComponentLoad = () => {
+        this.loadingDone = true;
+    };
+
+    ngOnDestroy(): void {
+        this.componentRef?.dispose();
     }
 }

--- a/examples/app1/src/app/projects/projects.component.ts
+++ b/examples/app1/src/app/projects/projects.component.ts
@@ -19,7 +19,7 @@ import { takeUntil } from 'rxjs/operators';
                     <!-- <ng-container
                         planetComponentOutlet="project1"
                         planetComponentOutletApp="app2"
-                        (planetComponentLoad)="planetComponentLoad($event)"
+                        (planetComponentLoaded)="planetComponentLoaded($event)"
                     ></ng-container> -->
                 </thy-tab>
                 <thy-tab id="planet-component-loader" thyTitle="PlanetComponentLoader">
@@ -69,7 +69,7 @@ export class ProjectsComponent implements OnInit, OnDestroy {
             });
     }
 
-    planetComponentLoad = ($event: PlanetComponentRef) => {
+    planetComponentLoaded = ($event: PlanetComponentRef) => {
         this.loadingDone = true;
     };
 

--- a/examples/app1/src/app/projects/projects.component.ts
+++ b/examples/app1/src/app/projects/projects.component.ts
@@ -19,7 +19,7 @@ import { takeUntil } from 'rxjs/operators';
                     <!-- <ng-container
                         planetComponentOutlet="project1"
                         planetComponentOutletApp="app2"
-                        (planetComponentLoad)="planetComponentLoad()"
+                        (planetComponentLoad)="planetComponentLoad($event)"
                     ></ng-container> -->
                 </thy-tab>
                 <thy-tab id="planet-component-loader" thyTitle="PlanetComponentLoader">
@@ -69,7 +69,7 @@ export class ProjectsComponent implements OnInit, OnDestroy {
             });
     }
 
-    planetComponentLoad = () => {
+    planetComponentLoad = ($event: PlanetComponentRef) => {
         this.loadingDone = true;
     };
 

--- a/examples/app1/src/app/shared.module.ts
+++ b/examples/app1/src/app/shared.module.ts
@@ -12,6 +12,7 @@ import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThyInputModule } from 'ngx-tethys/input';
 import { ThyFormModule } from 'ngx-tethys/form';
 import { ThySelectModule } from 'ngx-tethys/select';
+import { ThyTabsModule } from 'ngx-tethys/tabs';
 
 import { DemoCommonModule } from '@demo/common';
 import { NgxPlanetModule } from 'ngx-planet';
@@ -32,6 +33,7 @@ import { NgxPlanetModule } from 'ngx-planet';
         ThyInputModule,
         ThyFormModule,
         ThySelectModule,
+        ThyTabsModule,
         DemoCommonModule,
         NgxPlanetModule
     ],
@@ -49,6 +51,7 @@ import { NgxPlanetModule } from 'ngx-planet';
         ThyInputModule,
         ThyFormModule,
         ThySelectModule,
+        ThyTabsModule,
         DemoCommonModule,
         NgxPlanetModule
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/router": "^14.1.2",
         "bootstrap": "4.5.0",
         "date-fns": "^2.16.1",
-        "ngx-tethys": "14.0.7",
+        "ngx-tethys": "14.2.0-next.4",
         "rxjs": "~6.6.0",
         "tslib": "^2.1.0",
         "zone.js": "~0.11.4"
@@ -16119,9 +16119,9 @@
       }
     },
     "node_modules/ngx-tethys": {
-      "version": "14.0.7",
-      "resolved": "https://registry.npmjs.org/ngx-tethys/-/ngx-tethys-14.0.7.tgz",
-      "integrity": "sha512-F6YkSlZ4SuXfmci3Q1sSE34Cl7Kc/XJ+g6HW1YAExQdQK8VFcGZGmh0kV83X4Jy7uKQJ0PAAW0AJ1qU2/nDEaw==",
+      "version": "14.2.0-next.4",
+      "resolved": "https://registry.npmjs.org/ngx-tethys/-/ngx-tethys-14.2.0-next.4.tgz",
+      "integrity": "sha512-McRZ12rDlDic15GDsX7twdEQ+OV0hvuPD1MTVVowjpVTRo+wBI8mCDAuhbEnsbppIOhpsoyRAtL59uW1yZnCHQ==",
       "dependencies": {
         "cyia-code-util": "^1.0.4",
         "tslib": "^2.3.0"
@@ -34762,9 +34762,9 @@
       }
     },
     "ngx-tethys": {
-      "version": "14.0.7",
-      "resolved": "https://registry.npmjs.org/ngx-tethys/-/ngx-tethys-14.0.7.tgz",
-      "integrity": "sha512-F6YkSlZ4SuXfmci3Q1sSE34Cl7Kc/XJ+g6HW1YAExQdQK8VFcGZGmh0kV83X4Jy7uKQJ0PAAW0AJ1qU2/nDEaw==",
+      "version": "14.2.0-next.4",
+      "resolved": "https://registry.npmjs.org/ngx-tethys/-/ngx-tethys-14.2.0-next.4.tgz",
+      "integrity": "sha512-McRZ12rDlDic15GDsX7twdEQ+OV0hvuPD1MTVVowjpVTRo+wBI8mCDAuhbEnsbppIOhpsoyRAtL59uW1yZnCHQ==",
       "requires": {
         "cyia-code-util": "^1.0.4",
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@angular/router": "^14.1.2",
     "bootstrap": "4.5.0",
     "date-fns": "^2.16.1",
-    "ngx-tethys": "14.0.7",
+    "ngx-tethys": "14.2.0-next.4",
     "rxjs": "~6.6.0",
     "tslib": "^2.1.0",
     "zone.js": "~0.11.4"

--- a/packages/planet/.eslintrc.json
+++ b/packages/planet/.eslintrc.json
@@ -13,7 +13,7 @@
           "error",
           {
             "type": "attribute",
-            "prefix": "app",
+            "prefix": "planet",
             "style": "camelCase"
           }
         ],
@@ -21,7 +21,7 @@
           "error",
           {
             "type": "element",
-            "prefix": "lib",
+            "prefix": "planet",
             "style": "kebab-case"
           }
         ]

--- a/packages/planet/src/component/planet-component-loader.spec.ts
+++ b/packages/planet/src/component/planet-component-loader.spec.ts
@@ -17,6 +17,7 @@ import {
 } from '../global-planet';
 import { Planet } from 'ngx-planet/planet';
 import { RouterTestingModule } from '@angular/router/testing';
+import { PlanetComponentRef } from './planet-component-ref';
 
 describe('PlanetComponentLoader', () => {
     let compiler: Compiler;
@@ -93,6 +94,39 @@ describe('PlanetComponentLoader', () => {
             expect(componentRef.hostElement.classList.contains('planet-component-wrapper')).toBeTruthy();
             expect(componentRef.hostElement.classList.contains('custom-wrapper')).toBeTruthy();
         });
+    }));
+
+    it('should app2 load app1 component with hostClass', fakeAsync(() => {
+        // mock app1 and app2 bootstrap
+        const app1ModuleRef = defineAndBootstrapApplication(app1Name, App1Module);
+        const app2ModuleRef = defineAndBootstrapApplication(app2Name, App2Module);
+        tick();
+        registerAppComponents(app1ModuleRef);
+        loadApp1Component(app2ModuleRef, { hostClass: 'custom-host-class' }).subscribe(componentRef => {
+            expect(componentRef.hostElement.classList.contains('custom-host-class')).toBeTruthy();
+        });
+    }));
+
+    it('should load app1 component with comment container', fakeAsync(() => {
+        // mock app1 and app2 bootstrap
+        const app1ModuleRef = defineAndBootstrapApplication(app1Name, App1Module);
+        const app2ModuleRef = defineAndBootstrapApplication(app2Name, App2Module);
+        tick();
+        registerAppComponents(app1ModuleRef);
+        const componentLoader = app2ModuleRef.injector.get(PlanetComponentLoader);
+        const host = createComponentHostElement();
+        const comment = document.createComment('mock ng container');
+        host.appendChild(comment);
+        let componentRef: PlanetComponentRef;
+        componentLoader
+            .load(app1Name, 'app1-projects', Object.assign({}, { container: comment }))
+            .subscribe(_componentRef => {
+                componentRef = _componentRef;
+            });
+        tick(20);
+        expect(host.innerHTML).toContain(
+            `<app1-projects class="planet-component-wrapper" planet-inline=""> projects is work </app1-projects>`
+        );
     }));
 
     it('should app2 load app1 component with stylePrefix of app1', fakeAsync(() => {

--- a/packages/planet/src/component/planet-component-loader.spec.ts
+++ b/packages/planet/src/component/planet-component-loader.spec.ts
@@ -80,6 +80,7 @@ describe('PlanetComponentLoader', () => {
         }).toThrowError(`config 'container' cannot be null`);
 
         loadApp1ComponentAndExpectHtml(app2ModuleRef);
+        tick();
     }));
 
     it('should app2 load app1 component with wrapperClass', fakeAsync(() => {
@@ -89,8 +90,8 @@ describe('PlanetComponentLoader', () => {
         tick();
         registerAppComponents(app1ModuleRef);
         loadApp1Component(app2ModuleRef, { wrapperClass: 'custom-wrapper' }).subscribe(componentRef => {
-            expect(componentRef.wrapperElement.classList.contains('planet-component-wrapper')).toBeTruthy();
-            expect(componentRef.wrapperElement.classList.contains('custom-wrapper')).toBeTruthy();
+            expect(componentRef.hostElement.classList.contains('planet-component-wrapper')).toBeTruthy();
+            expect(componentRef.hostElement.classList.contains('custom-wrapper')).toBeTruthy();
         });
     }));
 
@@ -108,10 +109,10 @@ describe('PlanetComponentLoader', () => {
         });
         tick();
         registerAppComponents(app1ModuleRef);
-        loadApp1Component(app2ModuleRef, { wrapperClass: 'custom-wrapper' }).subscribe(componentRef => {
-            expect(componentRef.wrapperElement.classList.contains('planet-component-wrapper')).toBeTruthy();
-            expect(componentRef.wrapperElement.classList.contains('custom-wrapper')).toBeTruthy();
-            expect(componentRef.wrapperElement.classList.contains('app1-prefix')).toBeTruthy();
+        loadApp1Component(app2ModuleRef, { hostClass: 'custom-host' }).subscribe(componentRef => {
+            expect(componentRef.hostElement.classList.contains('planet-component-wrapper')).toBeTruthy();
+            expect(componentRef.hostElement.classList.contains('custom-host')).toBeTruthy();
+            expect(componentRef.hostElement.classList.contains('app1-prefix')).toBeTruthy();
         });
     }));
 
@@ -140,7 +141,7 @@ describe('PlanetComponentLoader', () => {
         tick();
         registerAppComponents(app1ModuleRef);
         loadApp1Component(app2ModuleRef).subscribe(componentRef => {
-            const parent = componentRef.wrapperElement.parentElement;
+            const parent = componentRef.hostElement.parentElement;
             componentRef.dispose();
             expect(parent.innerHTML).toEqual('');
         });
@@ -166,8 +167,8 @@ function loadApp1Component(appModuleRef: NgModuleRef<any>, config?: Partial<Plan
 
 function loadApp1ComponentAndExpectHtml(app2ModuleRef: NgModuleRef<any>) {
     loadApp1Component(app2ModuleRef).subscribe(componentRef => {
-        expect(componentRef.wrapperElement.outerHTML).toEqual(
-            `<div class="planet-component-wrapper" planet-inline=""><app1-projects> projects is work </app1-projects></div>`
+        expect(componentRef.hostElement.outerHTML).toEqual(
+            `<app1-projects class="planet-component-wrapper" planet-inline=""> projects is work </app1-projects>`
         );
     });
 }

--- a/packages/planet/src/component/planet-component-loader.ts
+++ b/packages/planet/src/component/planet-component-loader.ts
@@ -122,12 +122,13 @@ export class PlanetComponentLoader {
         const componentRef = componentFactory.create(injector);
         appRef.attachView(componentRef.hostView);
         const componentRootNode = this.getComponentRootNode(componentRef);
-        this.insertComponentRootNodeToContainer(container, componentRootNode, config.wrapperClass);
+        this.insertComponentRootNodeToContainer(container, componentRootNode, config.hostClass || config.wrapperClass);
         if (config.initialState) {
             Object.assign(componentRef.instance, config.initialState);
         }
         plantComponentRef.componentInstance = componentRef.instance;
         plantComponentRef.componentRef = componentRef;
+        plantComponentRef.hostElement = componentRootNode;
         plantComponentRef.dispose = () => {
             if (appRef.viewCount > 0) {
                 appRef.detachView(componentRef.hostView);
@@ -190,10 +191,7 @@ export class PlanetComponentLoader {
             }),
             shareReplay()
         );
-        // result.subscribe().add(() => {
-        //     console.log(`termdown`);
-        //     debugger;
-        // });
+        result.subscribe();
         return result;
     }
 }

--- a/packages/planet/src/component/planet-component-loader.ts
+++ b/packages/planet/src/component/planet-component-loader.ts
@@ -32,8 +32,6 @@ export interface PlanetComponent<T = any> {
     providedIn: 'root'
 })
 export class PlanetComponentLoader {
-    private domPortalOutletCache = new WeakMap<any, any>();
-
     private get applicationLoader() {
         return getApplicationLoader();
     }

--- a/packages/planet/src/component/planet-component-loader.ts
+++ b/packages/planet/src/component/planet-component-loader.ts
@@ -1,5 +1,17 @@
-import { Injectable, ApplicationRef, NgModuleRef, NgZone, ElementRef, Inject, Injector } from '@angular/core';
-import { ComponentType, DomPortalOutlet, ComponentPortal } from '@angular/cdk/portal';
+import {
+    Injectable,
+    ApplicationRef,
+    NgModuleRef,
+    NgZone,
+    ElementRef,
+    Inject,
+    Injector,
+    createComponent,
+    EnvironmentInjector,
+    Type,
+    ComponentRef,
+    EmbeddedViewRef
+} from '@angular/core';
 import { PlanetApplicationRef } from '../application/planet-application-ref';
 import { PlanetComponentRef } from './planet-component-ref';
 import { PlantComponentConfig } from './plant-component.config';
@@ -13,14 +25,14 @@ const componentWrapperClass = 'planet-component-wrapper';
 
 export interface PlanetComponent<T = any> {
     name: string;
-    component: ComponentType<T>;
+    component: Type<T>;
 }
 
 @Injectable({
     providedIn: 'root'
 })
 export class PlanetComponentLoader {
-    private domPortalOutletCache = new WeakMap<any, DomPortalOutlet>();
+    private domPortalOutletCache = new WeakMap<any, any>();
 
     private get applicationLoader() {
         return getApplicationLoader();
@@ -74,20 +86,26 @@ export class PlanetComponentLoader {
         }
     }
 
-    private createWrapperElement(config: PlantComponentConfig) {
-        const container = this.getContainerElement(config);
-        const element = this.document.createElement('div');
+    private insertComponentRootNodeToContainer(
+        container: HTMLElement,
+        componentRootNode: HTMLElement,
+        hostClass: string
+    ) {
         const subApp = this.applicationService.getAppByName(this.ngModuleRef.instance.appName);
-        element.classList.add(componentWrapperClass);
-        element.setAttribute('planet-inline', '');
-        if (config.wrapperClass) {
-            element.classList.add(config.wrapperClass);
+        componentRootNode.classList.add(componentWrapperClass);
+        componentRootNode.setAttribute('planet-inline', '');
+        if (hostClass) {
+            componentRootNode.classList.add(hostClass);
         }
         if (subApp && subApp.stylePrefix) {
-            element.classList.add(subApp.stylePrefix);
+            componentRootNode.classList.add(subApp.stylePrefix);
         }
-        container.appendChild(element);
-        return element;
+        // container 是注释则在前方插入，否则在元素内部插入
+        if (container.nodeType === 8) {
+            container.parentElement.insertBefore(componentRootNode, container);
+        } else {
+            container.appendChild(componentRootNode);
+        }
     }
 
     private attachComponent<TData>(
@@ -99,27 +117,29 @@ export class PlanetComponentLoader {
         const componentFactoryResolver = appModuleRef.componentFactoryResolver;
         const appRef = this.applicationRef;
         const injector = this.createInjector<TData>(appModuleRef, plantComponentRef);
-        const wrapper = this.createWrapperElement(config);
-        let portalOutlet = this.domPortalOutletCache.get(wrapper);
-        if (portalOutlet) {
-            portalOutlet.detach();
-        } else {
-            portalOutlet = new DomPortalOutlet(wrapper, componentFactoryResolver, appRef, injector);
-            this.domPortalOutletCache.set(wrapper, portalOutlet);
-        }
-        const componentPortal = new ComponentPortal(plantComponent.component, null);
-        const componentRef = portalOutlet.attachComponentPortal<TData>(componentPortal);
+        const container = this.getContainerElement(config);
+        const componentFactory = componentFactoryResolver.resolveComponentFactory(plantComponent.component);
+        const componentRef = componentFactory.create(injector);
+        appRef.attachView(componentRef.hostView);
+        const componentRootNode = this.getComponentRootNode(componentRef);
+        this.insertComponentRootNodeToContainer(container, componentRootNode, config.wrapperClass);
         if (config.initialState) {
             Object.assign(componentRef.instance, config.initialState);
         }
         plantComponentRef.componentInstance = componentRef.instance;
         plantComponentRef.componentRef = componentRef;
-        plantComponentRef.wrapperElement = wrapper;
         plantComponentRef.dispose = () => {
-            this.domPortalOutletCache.delete(wrapper);
-            portalOutlet.dispose();
+            if (appRef.viewCount > 0) {
+                appRef.detachView(componentRef.hostView);
+            }
+            componentRootNode.remove();
         };
         return plantComponentRef;
+    }
+
+    /** Gets the root HTMLElement for an instantiated component. */
+    private getComponentRootNode(componentRef: ComponentRef<any>): HTMLElement {
+        return (componentRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement;
     }
 
     private registerComponentFactory(componentOrComponents: PlanetComponent | PlanetComponent[]) {
@@ -170,7 +190,10 @@ export class PlanetComponentLoader {
             }),
             shareReplay()
         );
-        result.subscribe();
+        // result.subscribe().add(() => {
+        //     console.log(`termdown`);
+        //     debugger;
+        // });
         return result;
     }
 }

--- a/packages/planet/src/component/planet-component-outlet.spec.ts
+++ b/packages/planet/src/component/planet-component-outlet.spec.ts
@@ -1,0 +1,110 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NgxPlanetModule } from '../module';
+
+import { Component, DebugElement, OnInit } from '@angular/core';
+import { PlanetComponentLoader } from './planet-component-loader';
+import { PlantComponentConfig } from './plant-component.config';
+import { Observable, Subject } from 'rxjs';
+import { PlanetComponentRef } from './planet-component-ref';
+import { tap } from 'rxjs/operators';
+
+@Component({
+    selector: 'planet-component-outlet-basic-test',
+    template: `
+        <ng-container
+            *planetComponentOutlet="componentName; app: 'app2'; initialState: { term: 'From Test' }"
+        ></ng-container>
+    `
+})
+export class PlanetComponentOutletBasicTestComponent implements OnInit {
+    componentName = 'project1';
+
+    constructor() {}
+
+    // eslint-disable-next-line @angular-eslint/no-empty-lifecycle-method
+    ngOnInit(): void {}
+}
+
+class MockPlanetComponentLoader {
+    subject$ = new Subject<PlanetComponentRef>();
+
+    disposed = false;
+
+    mockPlanetComponentRef: PlanetComponentRef = {
+        hostElement: null,
+        dispose: () => {
+            this.mockPlanetComponentRef.hostElement?.remove();
+            this.disposed = true;
+        }
+    } as PlanetComponentRef;
+
+    load<TComp = unknown, TData = unknown>(
+        app: string,
+        componentName: string,
+        config: PlantComponentConfig<TData>
+    ): Observable<PlanetComponentRef<TComp>> {
+        return this.subject$.asObservable().pipe(
+            tap(() => {
+                const element = document.createElement(componentName);
+                element.innerHTML = app;
+                this.mockPlanetComponentRef.hostElement = element;
+                (config.container as HTMLElement).parentElement.insertBefore(element, config.container as HTMLElement);
+            })
+        );
+    }
+
+    mockLoadComponentRefSuccess() {
+        this.subject$.next(this.mockPlanetComponentRef);
+    }
+}
+
+describe('planet-component-outlet', () => {
+    let mockComponentLoader: MockPlanetComponentLoader;
+    let fixture: ComponentFixture<PlanetComponentOutletBasicTestComponent>;
+
+    beforeEach(() => {
+        mockComponentLoader = new MockPlanetComponentLoader();
+        TestBed.configureTestingModule({
+            declarations: [PlanetComponentOutletBasicTestComponent],
+            imports: [NgxPlanetModule],
+            providers: [
+                {
+                    provide: PlanetComponentLoader,
+                    useValue: mockComponentLoader
+                }
+            ]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(PlanetComponentOutletBasicTestComponent);
+        fixture.detectChanges();
+    });
+
+    it(`should load app2's project1 success`, () => {
+        const rootElement = fixture.debugElement.nativeElement as HTMLElement;
+        mockComponentLoader.mockLoadComponentRefSuccess();
+        expect(rootElement.innerHTML).toContain(`<project1>app2</project1>`);
+    });
+
+    it(`should dispose component when ngOnDestroy`, () => {
+        const rootElement = fixture.debugElement.nativeElement as HTMLElement;
+        mockComponentLoader.mockLoadComponentRefSuccess();
+        expect(rootElement.innerHTML).toContain(`<project1>app2</project1>`);
+        fixture.destroy();
+        expect(mockComponentLoader.disposed).toBe(true);
+        expect(rootElement.innerHTML).not.toContain(`<project1>app2</project1>`);
+    });
+
+    it(`should load component when name change`, () => {
+        const rootElement = fixture.debugElement.nativeElement as HTMLElement;
+        mockComponentLoader.mockLoadComponentRefSuccess();
+        expect(rootElement.innerHTML).toContain(`<project1>app2</project1>`);
+        fixture.componentInstance.componentName = 'other-component';
+        fixture.detectChanges();
+        expect(mockComponentLoader.disposed).toBe(true);
+        mockComponentLoader.mockLoadComponentRefSuccess();
+        expect(rootElement.innerHTML).not.toContain(`<project1>app2</project1>`);
+        expect(rootElement.innerHTML).toContain(`<other-component>app2</other-component>`);
+    });
+});

--- a/packages/planet/src/component/planet-component-outlet.spec.ts
+++ b/packages/planet/src/component/planet-component-outlet.spec.ts
@@ -32,7 +32,7 @@ export class PlanetComponentOutletBasicTestComponent implements OnInit {
             planetComponentOutlet="project1"
             planetComponentOutletApp="app2"
             planetComponentOutletInitialState="{ term: 'From Test' }"
-            (planetComponentLoad)="componentLoad($event)"
+            (planetComponentLoaded)="componentLoaded($event)"
         ></ng-container>
     `
 })
@@ -41,7 +41,7 @@ export class PlanetComponentOutletGeneralTestComponent {
 
     constructor() {}
 
-    componentLoad($event: PlanetComponentRef) {
+    componentLoaded($event: PlanetComponentRef) {
         this.planetComponentRef = $event;
     }
 }

--- a/packages/planet/src/component/planet-component-outlet.ts
+++ b/packages/planet/src/component/planet-component-outlet.ts
@@ -27,7 +27,7 @@ export class PlanetComponentOutlet implements OnChanges, OnDestroy, AfterViewIni
 
     @Input() planetComponentOutletInitialState: any;
 
-    @Output() planetComponentLoad = new EventEmitter<PlanetComponentRef>();
+    @Output() planetComponentLoaded = new EventEmitter<PlanetComponentRef>();
 
     private componentRef: PlanetComponentRef;
 
@@ -62,7 +62,7 @@ export class PlanetComponentOutlet implements OnChanges, OnDestroy, AfterViewIni
                     this.componentRef = componentRef;
                     this.ngZone.run(() => {
                         Promise.resolve().then(() => {
-                            this.planetComponentLoad.emit(this.componentRef);
+                            this.planetComponentLoaded.emit(this.componentRef);
                         });
                     });
                 });

--- a/packages/planet/src/component/planet-component-outlet.ts
+++ b/packages/planet/src/component/planet-component-outlet.ts
@@ -1,0 +1,76 @@
+import {
+    Directive,
+    ViewContainerRef,
+    OnDestroy,
+    OnChanges,
+    SimpleChanges,
+    Input,
+    AfterViewInit,
+    ElementRef,
+    NgZone,
+    Output,
+    EventEmitter
+} from '@angular/core';
+import { PlanetComponentLoader } from './planet-component-loader';
+import { PlanetComponentRef } from './planet-component-ref';
+
+@Directive({
+    selector: '[planetComponentOutlet]'
+})
+// eslint-disable-next-line @angular-eslint/directive-class-suffix
+export class PlanetComponentOutlet implements OnChanges, OnDestroy, AfterViewInit {
+    @Input() planetComponentOutlet: string;
+
+    @Input() planetComponentOutletApp: string;
+
+    @Input() planetComponentOutletInitialState: any;
+
+    @Output() planetComponentLoad = new EventEmitter();
+
+    private componentRef: PlanetComponentRef<unknown>;
+
+    constructor(
+        private viewContainerRef: ViewContainerRef,
+        private elementRef: ElementRef,
+        private planetComponentLoader: PlanetComponentLoader,
+        private ngZone: NgZone
+    ) {}
+
+    ngOnChanges(changes: SimpleChanges) {
+        if (this.planetComponentOutlet && !changes.planetComponentOutlet.isFirstChange()) {
+            this.loadComponent();
+        }
+    }
+
+    ngAfterViewInit(): void {
+        this.loadComponent();
+    }
+
+    loadComponent() {
+        this.clear();
+        if (this.planetComponentOutlet && this.planetComponentOutletApp) {
+            this.planetComponentLoader
+                .load(this.planetComponentOutletApp, this.planetComponentOutlet, {
+                    container: this.elementRef.nativeElement,
+                    initialState: this.planetComponentOutletInitialState
+                })
+                .subscribe(componentRef => {
+                    this.componentRef = componentRef;
+                    this.ngZone.run(() => {
+                        Promise.resolve().then(() => {
+                            this.planetComponentLoad.emit();
+                        });
+                    });
+                });
+        }
+    }
+
+    ngOnDestroy(): void {
+        this.clear();
+    }
+
+    clear() {
+        this.viewContainerRef.clear();
+        this.componentRef?.dispose();
+    }
+}

--- a/packages/planet/src/component/planet-component-outlet.ts
+++ b/packages/planet/src/component/planet-component-outlet.ts
@@ -27,9 +27,9 @@ export class PlanetComponentOutlet implements OnChanges, OnDestroy, AfterViewIni
 
     @Input() planetComponentOutletInitialState: any;
 
-    @Output() planetComponentLoad = new EventEmitter();
+    @Output() planetComponentLoad = new EventEmitter<PlanetComponentRef>();
 
-    private componentRef: PlanetComponentRef<unknown>;
+    private componentRef: PlanetComponentRef;
 
     private destroyed$ = new Subject<void>();
 
@@ -41,7 +41,6 @@ export class PlanetComponentOutlet implements OnChanges, OnDestroy, AfterViewIni
 
     ngOnChanges(changes: SimpleChanges) {
         if (this.planetComponentOutlet && !changes.planetComponentOutlet.isFirstChange()) {
-            console.log(this.planetComponentOutlet);
             this.loadComponent();
         }
     }
@@ -63,7 +62,7 @@ export class PlanetComponentOutlet implements OnChanges, OnDestroy, AfterViewIni
                     this.componentRef = componentRef;
                     this.ngZone.run(() => {
                         Promise.resolve().then(() => {
-                            this.planetComponentLoad.emit();
+                            this.planetComponentLoad.emit(this.componentRef);
                         });
                     });
                 });

--- a/packages/planet/src/component/planet-component-ref.ts
+++ b/packages/planet/src/component/planet-component-ref.ts
@@ -2,6 +2,7 @@ import { ComponentRef, ElementRef } from '@angular/core';
 
 export class PlanetComponentRef<TComp = any> {
     wrapperElement: HTMLElement;
+    hostElement: HTMLElement;
     componentInstance: TComp;
     componentRef: ComponentRef<TComp>;
     dispose: () => void;

--- a/packages/planet/src/component/plant-component.config.ts
+++ b/packages/planet/src/component/plant-component.config.ts
@@ -5,7 +5,7 @@ export class PlantComponentConfig<TData = any> {
     container: HTMLElement | ElementRef<HTMLElement | any> | Comment;
     /**
      * Wrapper class of plant component
-     * @deprecated
+     * @deprecated please use hostClass
      */
     wrapperClass?: string;
     /**

--- a/packages/planet/src/component/plant-component.config.ts
+++ b/packages/planet/src/component/plant-component.config.ts
@@ -2,7 +2,7 @@ import { ViewContainerRef, ElementRef } from '@angular/core';
 
 export class PlantComponentConfig<TData = any> {
     /** Load target container */
-    container: HTMLElement | ElementRef<HTMLElement | any>;
+    container: HTMLElement | ElementRef<HTMLElement | any> | Comment;
     /**
      * Wrapper class of plant component
      * @deprecated

--- a/packages/planet/src/component/plant-component.config.ts
+++ b/packages/planet/src/component/plant-component.config.ts
@@ -3,8 +3,15 @@ import { ViewContainerRef, ElementRef } from '@angular/core';
 export class PlantComponentConfig<TData = any> {
     /** Load target container */
     container: HTMLElement | ElementRef<HTMLElement | any>;
-    /** Component wrapper class. */
+    /**
+     * Wrapper class of plant component
+     * @deprecated
+     */
     wrapperClass?: string;
+    /**
+     * Host class of plant component
+     */
+    hostClass?: string;
     /** Data being injected into the child component. */
     initialState?: TData | null = null;
 }

--- a/packages/planet/src/module.ts
+++ b/packages/planet/src/module.ts
@@ -2,12 +2,13 @@ import { NgModule, ModuleWithProviders } from '@angular/core';
 import { PlanetApplication, PLANET_APPLICATIONS } from './planet.class';
 import { HttpClientModule } from '@angular/common/http';
 import { EmptyComponent } from './empty/empty.component';
+import { PlanetComponentOutlet } from './component/planet-component-outlet';
 
 @NgModule({
-    declarations: [EmptyComponent],
+    declarations: [EmptyComponent, PlanetComponentOutlet],
     imports: [HttpClientModule],
     providers: [],
-    exports: [HttpClientModule, EmptyComponent]
+    exports: [HttpClientModule, EmptyComponent, PlanetComponentOutlet]
 })
 export class NgxPlanetModule {
     static forRoot(apps: PlanetApplication[]): ModuleWithProviders<NgxPlanetModule> {


### PR DESCRIPTION
1. Remove @angular/cdk deps, use `@angular/core` api create component
2. Remove Wrapper element and deprecated `wrapperClass`
3. Support container is #comment element，insert host element before it
4. Add `hostClass` instead of `wrapperClass`
5. Add `PlanetComponentOutlet` directive dynamic load component and auto dispose when directive is destroy, recommend `PlanetComponentOutlet` instead of PlanetComponentLoader