### PR TITLE
feat: add routeRedirect function redirect to relative url instead of route definition redirectTo

### DIFF
--- a/examples/app1/src/app/app.module.ts
+++ b/examples/app1/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { NavigationStart, Router, RouterModule } from '@angular/router';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { routers } from './app.routing';
 import { AppRootComponent, AppActualRootComponent } from './root/root.component';
@@ -39,5 +39,11 @@ import { SharedModule } from './shared.module';
     bootstrap: [AppRootComponent]
 })
 export class AppModule {
-    constructor() {}
+    constructor(private router: Router) {
+        this.router.events.subscribe(event => {
+            if (event instanceof NavigationStart) {
+                console.log(`[App1] url: ${event.url}, id: ${event.id}, navigationTrigger: ${event.navigationTrigger}`);
+            }
+        });
+    }
 }

--- a/examples/app1/src/app/app.routing.ts
+++ b/examples/app1/src/app/app.routing.ts
@@ -10,11 +10,11 @@ export const routers: Route[] = [
         path: 'app1',
         component: AppActualRootComponent,
         children: [
-            {
-                path: '',
-                redirectTo: 'dashboard',
-                pathMatch: 'full'
-            },
+            // {
+            //     path: '',
+            //     redirectTo: 'dashboard',
+            //     pathMatch: 'full'
+            // },
             {
                 path: 'dashboard',
                 component: DashboardComponent

--- a/examples/app1/src/app/root/root.component.ts
+++ b/examples/app1/src/app/root/root.component.ts
@@ -1,5 +1,5 @@
-import { Component, HostBinding, NgZone } from '@angular/core';
-import { GlobalEventDispatcher } from 'ngx-planet';
+import { Component, HostBinding, NgZone, inject, ChangeDetectorRef, Injectable, OnInit, ViewRef } from '@angular/core';
+import { GlobalEventDispatcher, routeRedirect } from 'ngx-planet';
 import { ThyDialog } from 'ngx-tethys/dialog';
 import { UserDetailComponent } from '../user/detail/user-detail.component';
 
@@ -10,6 +10,10 @@ import { UserDetailComponent } from '../user/detail/user-detail.component';
 })
 export class AppActualRootComponent {
     @HostBinding(`class.thy-layout`) isLayout = true;
+
+    redirect = routeRedirect('dashboard');
+
+    constructor() {}
 }
 
 @Component({

--- a/examples/app2/src/app/app.module.ts
+++ b/examples/app2/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 
-import { RouterModule, Route } from '@angular/router';
+import { RouterModule, Route, Router, NavigationStart } from '@angular/router';
 import { ProjectListComponent } from './projects/project-list.component';
 import { AppRootComponent, AppActualRootComponent } from './root/root.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
@@ -23,11 +23,11 @@ const routers: Route[] = [
         path: 'app2',
         component: AppActualRootComponent,
         children: [
-            {
-                path: '',
-                redirectTo: 'dashboard',
-                pathMatch: 'full'
-            },
+            // {
+            //     path: '',
+            //     redirectTo: 'dashboard',
+            //     pathMatch: 'full'
+            // },
             {
                 path: 'users',
                 loadChildren: () => import('./user/user.module').then(mod => mod.UserModule)
@@ -90,4 +90,12 @@ const routers: Route[] = [
     providers: [OVERLAY_PROVIDER, { provide: Overlay, useClass: AppOverlay }],
     bootstrap: [AppRootComponent]
 })
-export class AppModule {}
+export class AppModule {
+    constructor(private router: Router) {
+        this.router.events.subscribe(event => {
+            if (event instanceof NavigationStart) {
+                console.log(`[App2] url: ${event.url}, id: ${event.id}, navigationTrigger: ${event.navigationTrigger}`);
+            }
+        });
+    }
+}

--- a/examples/app2/src/app/root/root.component.ts
+++ b/examples/app2/src/app/root/root.component.ts
@@ -1,6 +1,7 @@
-import { PlanetComponentLoader } from 'ngx-planet';
-import { Component, HostBinding, ComponentFactoryResolver, Injector, ApplicationRef, OnInit } from '@angular/core';
+import { PlanetComponentLoader, routeRedirect } from 'ngx-planet';
+import { Component, HostBinding, OnInit } from '@angular/core';
 import { ProjectListComponent } from '../projects/project-list.component';
+
 @Component({
     selector: 'app2-root-actual',
     templateUrl: './root.component.html',
@@ -9,6 +10,8 @@ import { ProjectListComponent } from '../projects/project-list.component';
 export class AppActualRootComponent {
     @HostBinding(`class.thy-layout`) isThyLayout = true;
     @HostBinding(`class.thy-layout--has-sidebar`) isThyHasSidebarLayout = true;
+
+    routeRedirect = routeRedirect('dashboard');
 
     constructor() {}
 }

--- a/examples/portal/src/app/app.module.ts
+++ b/examples/portal/src/app/app.module.ts
@@ -27,6 +27,7 @@ import { AppRootContext, DemoCommonModule, OVERLAY_PROVIDER } from '@demo/common
 import { FormsModule } from '@angular/forms';
 import { Overlay } from '@angular/cdk/overlay';
 import { AppOverlay } from './overlay';
+import { NavigationStart, Router } from '@angular/router';
 
 @NgModule({
     declarations: [AppComponent, AboutComponent, SettingsComponent, ADetailComponent],
@@ -57,7 +58,15 @@ import { AppOverlay } from './overlay';
     bootstrap: [AppComponent]
 })
 export class AppModule {
-    constructor(iconRegistry: ThyIconRegistry, domSanitizer: DomSanitizer) {
+    constructor(iconRegistry: ThyIconRegistry, domSanitizer: DomSanitizer, private router: Router) {
         iconRegistry.addSvgIconSet(domSanitizer.bypassSecurityTrustResourceUrl('assets/icons/sprite.defs.svg'));
+
+        this.router.events.subscribe(event => {
+            if (event instanceof NavigationStart) {
+                console.log(
+                    `[Portal] url: ${event.url}, id: ${event.id}, navigationTrigger: ${event.navigationTrigger}`
+                );
+            }
+        });
     }
 }

--- a/packages/planet/src/public-api.ts
+++ b/packages/planet/src/public-api.ts
@@ -17,3 +17,4 @@ export { PlanetComponentRef } from './component/planet-component-ref';
 export { PlanetComponentOutlet } from './component/planet-component-outlet';
 export { PlantComponentConfig } from './component/plant-component.config';
 export * from './empty/empty.component';
+export * from './router/route-redirect';

--- a/packages/planet/src/router/route-redirect.spec.ts
+++ b/packages/planet/src/router/route-redirect.spec.ts
@@ -1,0 +1,35 @@
+import { Component, inject } from '@angular/core';
+import { Location } from '@angular/common';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router, provideRouter } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { routeRedirect } from './route-redirect';
+import { BehaviorSubject } from 'rxjs';
+
+describe('route-redirect', () => {
+    it('should redirect to success', async () => {
+        @Component({ standalone: true, template: '' })
+        class TestComponent {
+            routeRedirect = routeRedirect('hello');
+        }
+
+        @Component({ standalone: true, template: 'hello world' })
+        class HelloComponent {}
+
+        TestBed.configureTestingModule({
+            providers: [
+                provideRouter([
+                    { path: '', component: TestComponent },
+                    { path: 'hello', component: HelloComponent }
+                ])
+            ]
+        });
+
+        const harness = await RouterTestingHarness.create();
+        const router = TestBed.inject(Router);
+        const activatedComponent = await harness.navigateByUrl('/');
+        expect(activatedComponent).toBeInstanceOf(HelloComponent);
+        expect(harness.routeNativeElement?.innerHTML).toContain('hello world');
+        console.log(router.lastSuccessfulNavigation);
+    });
+});

--- a/packages/planet/src/router/route-redirect.spec.ts
+++ b/packages/planet/src/router/route-redirect.spec.ts
@@ -30,6 +30,5 @@ describe('route-redirect', () => {
         const activatedComponent = await harness.navigateByUrl('/');
         expect(activatedComponent).toBeInstanceOf(HelloComponent);
         expect(harness.routeNativeElement?.innerHTML).toContain('hello world');
-        console.log(router.lastSuccessfulNavigation);
     });
 });

--- a/packages/planet/src/router/route-redirect.ts
+++ b/packages/planet/src/router/route-redirect.ts
@@ -1,0 +1,27 @@
+import { inject } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+class RouteRedirect {
+    activatedRoute = inject(ActivatedRoute);
+    router = inject(Router);
+
+    constructor(redirectTo: string) {
+        const finalRedirectTo = redirectTo || this.activatedRoute.snapshot.data.redirectTo;
+        if (finalRedirectTo) {
+            this.router.navigate(
+                [`${finalRedirectTo}`],
+                // By replacing the current URL in the history, we keep the Browser's Back
+                // Button behavior in tact. This will allow the user to easily navigate back
+                // to the previous URL without getting caught in a redirect.
+                {
+                    replaceUrl: true,
+                    relativeTo: this.activatedRoute
+                }
+            );
+        }
+    }
+}
+
+export function routeRedirect(redirectTo?: string) {
+    return new RouteRedirect(redirectTo);
+}


### PR DESCRIPTION
修复缺陷：https://github.com/worktile/ngx-planet/issues/288

```ts
export class AppActualRootComponent {
    redirect = routeRedirect('dashboard');
}
```

使用 routeRedirect 函数传递相对路由地址，即可在组件中跳转路由，跳转时设置 replaceUrl 为 true，不在 URL 中生成当前组件的路由地址。

这个主要是因为如下的方案定义路由时， Angular 不会在 Location 中新增一个 state，所以如果单个应用这样处理点击回退时不会有 app1 的地址的。
```ts
export const routers: Route[] = [
    {
        path: 'app1',
        component: AppActualRootComponent,
        children: [
            {
                 path: '',
                 redirectTo: 'dashboard',
                 pathMatch: 'full'
             },
            {
                path: 'dashboard',
                component: DashboardComponent
            }
];
```

但是微前端下就不行，app1 应用不会在 Location 加 state，但是其他应用会加，这就导致回退的时候变成了 app1，需要回退两次。

解决方案就是手动通过代码的方式跳转